### PR TITLE
feat: Implement core Minecraft-like mechanics

### DIFF
--- a/block.py
+++ b/block.py
@@ -1,0 +1,100 @@
+from panda3d.core import NodePath, PandaNode, Point3, Texture, TextureStage
+from panda3d.core import TexturePool, TransparencyAttrib # TransparencyAttrib might not be needed now
+from panda3d.core import Vec3
+
+class Block(NodePath):
+    # Pre-load textures to avoid loading them for every block instance
+    textures = {}
+
+    @classmethod
+    def load_block_textures(cls, loader):
+        # User will need to create a 'textures' folder and place these files in it.
+        # For grass, we'll use grass_side for all faces for simplicity with the default box model.
+        # A more advanced setup would use different textures for top/bottom/sides.
+        try:
+            cls.textures["grass"] = loader.loadTexture("textures/grass_side.png")
+            cls.textures["grass"].setMagfilter(Texture.FTNearest)
+            cls.textures["grass"].setMinfilter(Texture.FTNearestMipmapNearest)
+        except Exception as e:
+            print(f"Warning: Could not load grass texture: {e}. Using fallback color.")
+            cls.textures["grass"] = None
+
+        try:
+            cls.textures["stone"] = loader.loadTexture("textures/stone.png")
+            cls.textures["stone"].setMagfilter(Texture.FTNearest)
+            cls.textures["stone"].setMinfilter(Texture.FTNearestMipmapNearest)
+        except Exception as e:
+            print(f"Warning: Could not load stone texture: {e}. Using fallback color.")
+            cls.textures["stone"] = None
+
+        # Example for a more complex grass block if using a model with multiple texture stages
+        # or a custom shader:
+        # cls.textures["grass_top"] = loader.loadTexture("textures/grass_top.png")
+        # cls.textures["dirt"] = loader.loadTexture("textures/dirt.png")
+
+
+    def __init__(self, base, position=Vec3(0,0,0), block_type="stone"):
+        NodePath.__init__(self, PandaNode(f"block-{block_type}-{position}"))
+        self.base = base
+        self.block_type = block_type
+
+        if not Block.textures: # Ensure textures are loaded once
+            Block.load_block_textures(self.base.loader)
+
+        self.model = self.base.loader.loadModel("models/box")
+        self.model.reparentTo(self)
+
+        self.setPos(position)
+        self.set_texture(block_type)
+
+        # Collision setup for the block
+        # This allows the player and mouse ray to interact with it.
+        from panda3d.core import CollisionNode, CollisionBox, BitMask32
+        cNode = CollisionNode(self.getName() + "_cnode")
+        # Assuming block is 1x1x1 centered at its origin
+        cNode.addSolid(CollisionBox(Point3(-0.5, -0.5, -0.5), Point3(0.5, 0.5, 0.5)))
+        cNode.setIntoCollideMask(BitMask32.bit(0)) # World collision mask
+        cNode.setFromCollideMask(BitMask32.allOff())
+        self.collision_np = self.attachNewNode(cNode)
+        # self.collision_np.show() # For debugging
+
+    def set_texture(self, block_type):
+        tex = Block.textures.get(block_type)
+        if tex:
+            self.model.setTexture(tex, 1)
+            self.model.setColorOff() # Remove fallback color if texture is applied
+        else:
+            # Fallback to color if texture is missing
+            if block_type == "grass":
+                self.model.setColor(0, 0.5, 0, 1) # Green
+            elif block_type == "stone":
+                self.model.setColor(0.5, 0.5, 0.5, 1) # Grey
+            else:
+                self.model.setColor(1,1,1,1) # White for unknown
+
+    def remove(self):
+        # Clean up the block
+        if self.collision_np:
+            self.collision_np.removeNode()
+        if self.model:
+            self.model.removeNode()
+        self.removeNode()
+
+# Example usage (will be managed by a World class or similar later)
+if __name__ == '__main__':
+    from direct.showbase.ShowBase import ShowBase
+    app = ShowBase()
+
+    # Create some blocks
+    b1 = Block(app, position=Vec3(0,0,0), block_type="grass")
+    b1.reparentTo(app.render)
+
+    b2 = Block(app, position=Vec3(1,0,0), block_type="stone")
+    b2.reparentTo(app.render)
+
+    b3 = Block(app, position=Vec3(0,1,0), block_type="grass")
+    b3.reparentTo(app.render)
+
+    app.camera.setPos(5, -5, 5)
+    app.camera.lookAt(0,0,0)
+    app.run()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,217 @@
+from direct.showbase.ShowBase import ShowBase
+from panda3d.core import CollisionTraverser, CollisionHandlerQueue, CollisionRay, CollisionNode, BitMask32, Point3, Vec3
+from player import Player
+from block import Block # Import the Block class
+import math # For rounding positions
+
+class MyApp(ShowBase):
+    def __init__(self):
+        ShowBase.__init__(self)
+
+        # Set up a simple light
+        self.setup_lights()
+
+        # Set up the camera - mouse will be enabled for picking
+        # self.disableMouse() # We need mouse for picking, but default controls are not ideal
+        self.camLens.setFov(90) # Wider FOV
+        self.camLens.setNear(0.1) # Closer near plane for picking
+
+        # Initialize collision system
+        self.cTrav = CollisionTraverser("main_traverser")
+        # self.cTrav.showCollisions(self.render) # For debugging collisions
+
+        # Create the player
+        self.player = Player(self)
+
+        # World state
+        self.blocks = {} # Dictionary to store blocks, mapping position tuple to Block instance
+
+        # Mouse picking setup
+        self.picker_ray = CollisionRay()
+        picker_node = CollisionNode('mouse_ray_cnode')
+        picker_node.addSolid(self.picker_ray)
+        picker_node.setFromCollideMask(BitMask32.allOff()) # Rays don't have a 'from' type / don't act as solid objects
+        picker_node.setIntoCollideMask(BitMask32.bit(0))   # Ray collides with world objects (mask 0)
+        self.picker_np = self.camera.attachNewNode(picker_node)
+        self.picker_handler = CollisionHandlerQueue()
+        self.cTrav.addCollider(self.picker_np, self.picker_handler)
+
+        # Input for block manipulation
+        self.accept("mouse1", self.handle_left_click)    # Break block
+        self.accept("mouse3", self.handle_right_click)   # Place block
+
+        # Current block type to place
+        self.current_block_type_to_place = "stone" # Default to stone
+        self.accept("1", self.set_block_type_to_place, ["stone"])
+        self.accept("2", self.set_block_type_to_place, ["grass"])
+
+
+        # Update camera to follow player (and allow mouse look)
+        self.taskMgr.add(self.update_camera_and_mouse_look, "update_camera_and_mouse_look_task")
+
+        # Load block textures once
+        Block.load_block_textures(self.loader)
+
+        # Generate the world
+        self.generate_world(size_x=10, size_y=10, ground_height=0, grass_depth=1, stone_depth=2)
+
+
+    def generate_world(self, size_x, size_y, ground_height, grass_depth, stone_depth):
+        print(f"Generating world: {size_x}x{size_y}, ground at Z={ground_height}")
+        for x in range(-size_x // 2, size_x // 2):
+            for y in range(-size_y // 2, size_y // 2):
+                # Grass layer
+                for d in range(grass_depth):
+                    self.add_block(Point3(x, y, ground_height - d), "grass")
+                # Stone layer underneath
+                for d in range(grass_depth, grass_depth + stone_depth):
+                    self.add_block(Point3(x, y, ground_height - d), "stone")
+
+        # Ensure player starts on top of the generated world
+        # Player's initial Z is 2, model_height_offset is 0.3. Feet at 1.7.
+        # If ground_height is 0, this should be fine.
+        # If ground_height changes, player start pos might need adjustment.
+        # For now, player starts at (0,0,2) and should fall onto the ground_height=0 plane.
+
+
+    def setup_lights(self):
+        # Ambient Light
+        from panda3d.core import AmbientLight
+        ambient_light = AmbientLight('ambient_light')
+        ambient_light.setColor((0.3, 0.3, 0.3, 1))
+        self.ambient_light_node = self.render.attachNewNode(ambient_light)
+        self.render.setLight(self.ambient_light_node)
+
+        # Directional Light
+        from panda3d.core import DirectionalLight
+        directional_light = DirectionalLight('directional_light')
+        directional_light.setColor((0.8, 0.8, 0.8, 1))
+        directional_light.setShadowCaster(True, 512, 512)
+        self.directional_light_node = self.render.attachNewNode(directional_light)
+        self.directional_light_node.setHpr(0, -60, 0) # Direction of the light
+        self.render.setLight(self.directional_light_node)
+        self.render.setShaderAuto()
+
+    def set_block_type_to_place(self, block_type):
+        print(f"Selected block type: {block_type}")
+        self.current_block_type_to_place = block_type
+
+    def add_block(self, position, block_type):
+        # Round position to nearest grid cell
+        pos_tuple = (round(position.x), round(position.y), round(position.z))
+
+        if pos_tuple not in self.blocks:
+            print(f"Adding {block_type} block at {pos_tuple}")
+            new_block = Block(self, Vec3(pos_tuple), block_type)
+            new_block.reparentTo(self.render)
+            self.blocks[pos_tuple] = new_block
+            return new_block
+        return None
+
+    def remove_block(self, block_instance):
+        if block_instance:
+            pos_tuple = (round(block_instance.getX()), round(block_instance.getY()), round(block_instance.getZ()))
+            print(f"Removing block at {pos_tuple}")
+            if pos_tuple in self.blocks:
+                self.blocks[pos_tuple].remove()
+                del self.blocks[pos_tuple]
+
+    def get_block_hit(self):
+        if self.mouseWatcherNode.hasMouse():
+            mpos = self.mouseWatcherNode.getMouse()
+            self.picker_ray.setFromLens(self.camNode, mpos.getX(), mpos.getY())
+
+            self.cTrav.traverse(self.render) # Check collisions with render
+
+            if self.picker_handler.getNumEntries() > 0:
+                self.picker_handler.sortEntries() # Sort by distance
+                entry = self.picker_handler.getEntry(0)
+                picked_node_path = entry.getIntoNodePath()
+
+                # Traverse up to find the parent 'Block' instance if it exists
+                current_np = picked_node_path
+                while current_np != self.render and current_np.getParent() != self.render:
+                    if isinstance(current_np.node(), PandaNode) and "block-" in current_np.getName(): # Check if it's one of our blocks
+                        # Find the Block instance associated with this NodePath
+                        for block in self.blocks.values():
+                            if block == current_np:
+                                return block, entry.getSurfacePoint(self.render), entry.getSurfaceNormal(self.render)
+                    current_np = current_np.getParent()
+                # If the hit object is directly a block (e.g. no complex hierarchy within block.model)
+                if isinstance(picked_node_path.node(), PandaNode) and "block-" in picked_node_path.getName():
+                     for block in self.blocks.values():
+                            if block == picked_node_path:
+                                return block, entry.getSurfacePoint(self.render), entry.getSurfaceNormal(self.render)
+
+        return None, None, None
+
+
+    def handle_left_click(self): # Break block
+        block_hit, hit_pos, hit_normal = self.get_block_hit()
+        if block_hit:
+            self.remove_block(block_hit)
+
+    def handle_right_click(self): # Place block
+        block_hit, hit_pos, hit_normal = self.get_block_hit()
+        if hit_pos is not None and hit_normal is not None:
+            # Calculate placement position: on the face of the hit block
+            # Ensure the new block is snapped to the grid
+            place_pos = hit_pos + hit_normal * 0.5 # Place adjacent to the hit surface
+
+            # Snap to grid more reliably
+            # The idea is to find the center of the block we'd be placing if we were inside the hit block's cell, then offset by normal
+            if block_hit:
+                target_block_center = block_hit.getPos()
+                new_block_center_x = target_block_center.x + hit_normal.x
+                new_block_center_y = target_block_center.y + hit_normal.y
+                new_block_center_z = target_block_center.z + hit_normal.z
+                final_place_pos = Point3(round(new_block_center_x), round(new_block_center_y), round(new_block_center_z))
+            else: # Fallback if not hitting a block (e.g. placing on an imaginary plane)
+                 final_place_pos = Point3(round(place_pos.x), round(place_pos.y), round(place_pos.z))
+
+            # Prevent placing block inside player
+            player_pos_rounded = Point3(round(self.player.getX()), round(self.player.getY()), round(self.player.getZ()))
+            player_head_pos_rounded = Point3(round(self.player.getX()), round(self.player.getY()), round(self.player.getZ() + 1)) # Approx head
+
+            if final_place_pos == player_pos_rounded or final_place_pos == player_head_pos_rounded:
+                print("Cannot place block inside player.")
+                return
+
+            self.add_block(final_place_pos, self.current_block_type_to_place)
+
+
+    def update_camera_and_mouse_look(self, task):
+        # Basic first-person camera controls
+        md = self.win.getPointer(0)
+        x = md.getX()
+        y = md.getY()
+
+        if self.win.movePointer(0, self.win.getXSize() // 2, self.win.getYSize() // 2):
+            self.player.setH(self.player.getH() - (x - self.win.getXSize() // 2) * 0.1)
+            self.camera.setP(self.camera.getP() - (y - self.win.getYSize() // 2) * 0.1)
+
+            # Clamp camera pitch
+            min_pitch = -85
+            max_pitch = 85
+            if self.camera.getP() < min_pitch:
+                self.camera.setP(min_pitch)
+            elif self.camera.getP() > max_pitch:
+                self.camera.setP(max_pitch)
+
+        # Camera follows player's position and orientation (H from player, P from camera itself)
+        self.camera.setPos(self.player.getPos() + (0,0,0.5)) # Camera at player's eye level
+        self.camera.setHpr(self.player.getH(), self.camera.getP(), 0) # Player H, Camera P, 0 Roll
+
+        # Update player's orientation for movement if needed (player model faces where camera looks horizontally)
+        # This means player model will rotate with mouse H.
+        # If you want player model to be independent of camera H, then don't do this.
+        # self.player.model.setHpr(self.camera.getH(), 0, 0) # Or self.player.getH() if player has own rotation logic
+
+        # Run collision traversal for player physics (and picker, though picker also traverses on click)
+        self.cTrav.traverse(self.render)
+
+        return task.cont
+
+
+app = MyApp()
+app.run()

--- a/player.py
+++ b/player.py
@@ -1,0 +1,203 @@
+from panda3d.core import NodePath, PandaNode, Point3, Vec3
+from panda3d.core import CollisionSphere, CollisionNode, CollisionHandlerQueue, CollisionRay, CollisionHandlerPusher, BitMask32
+from direct.showbase.ShowBaseGlobal import globalClock
+
+class Player(NodePath):
+    def __init__(self, base):
+        self.base = base
+        NodePath.__init__(self, PandaNode("player"))
+        self.reparentTo(self.base.render) # Player NodePath is now child of render
+
+        # Player model (simple sphere for now)
+        self.model = self.base.loader.loadModel("models/misc/sphere")
+        self.model.reparentTo(self) # Model is child of Player NodePath
+        self.model.setScale(0.3)
+        self.model_height_offset = 0.3 # Radius of the sphere, for ground check
+        self.setPos(0, 0, 2) # Initial position, higher to fall onto blocks
+
+        # Movement variables
+        self.speed = 5.0
+        self.jump_force = 7.0 # Adjusted jump force
+        self.gravity = -19.6
+        self.vertical_velocity = 0.0
+        self.is_jumping = False
+        self.on_ground = False # Start in the air
+
+        # Input state
+        self.key_map = {
+            "forward": False, "backward": False, "left": False, "right": False, "jump": False
+        }
+
+        # Setup input
+        self.base.accept("w", self.set_key, ["forward", True])
+        self.base.accept("w-up", self.set_key, ["forward", False])
+        self.base.accept("s", self.set_key, ["backward", True])
+        self.base.accept("s-up", self.set_key, ["backward", False])
+        self.base.accept("a", self.set_key, ["left", True])
+        self.base.accept("a-up", self.set_key, ["left", False])
+        self.base.accept("d", self.set_key, ["right", True])
+        self.base.accept("d-up", self.set_key, ["right", False])
+        self.base.accept("space", self.set_key, ["jump", True])
+        # "space-up" is not strictly needed for this jump logic but good practice
+        self.base.accept("space-up", self.set_key, ["jump", False])
+
+        # Collision setup for ground detection (ray from player center downwards)
+        self.ground_ray = CollisionRay()
+        # Ray origin is at player's feet (center - offset)
+        self.ground_ray.setOrigin(0, 0, -self.model_height_offset + 0.05) # Start ray slightly inside the model bottom
+        self.ground_ray.setDirection(0, 0, -1) # Shoots downwards
+
+        self.ground_col_node = CollisionNode('player_ground_ray_cnode')
+        self.ground_col_node.addSolid(self.ground_ray)
+        self.ground_col_node.setFromCollideMask(BitMask32.allOff()) # Ray should not be solid itself
+        self.ground_col_node.setIntoCollideMask(BitMask32.bit(0))   # Ray collides with world objects (mask 0)
+        self.ground_col_np = self.attachNewNode(self.ground_col_node) # Attach to player NodePath
+        # self.ground_col_np.show() # For debugging the ray
+
+        self.ground_handler = CollisionHandlerQueue()
+        # Add player's ground ray to the main traverser in MyApp
+        self.base.cTrav.addCollider(self.ground_col_np, self.ground_handler)
+
+        # Collision setup for player body (sphere) to prevent walking through blocks
+        player_col_solid = CollisionSphere(0, 0, 0, self.model_height_offset * 1.1) # Slightly larger than visual model
+        self.player_col_node = CollisionNode('player_collider_cnode')
+        self.player_col_node.addSolid(player_col_solid)
+        self.player_col_node.setFromCollideMask(BitMask32.bit(1)) # Player collision mask
+        self.player_col_node.setIntoCollideMask(BitMask32.bit(0))   # Collide with world
+        self.player_col_np = self.attachNewNode(self.player_col_node)
+        # self.player_col_np.show()
+
+        self.player_pusher = CollisionHandlerPusher()
+        self.player_pusher.addCollider(self.player_col_np, self) # Pusher will move 'self' (the Player NodePath)
+        self.base.cTrav.addCollider(self.player_col_np, self.player_pusher)
+
+
+        # Task for player update
+        self.base.taskMgr.add(self.update_player, "update_player_task")
+
+    def set_key(self, key, value):
+        self.key_map[key] = value
+        if key == "jump" and value == False: # Handle jump release if needed for future mechanics
+            pass
+
+
+    def update_player(self, task):
+        dt = globalClock.getDt()
+        current_pos = self.getPos()
+
+        # --- Ground Detection ---
+        self.on_ground = False # Assume not on ground until ray confirms
+        # self.base.cTrav.traverse(self.base.render) # Traversal is done in main loop or by MyApp's traverser
+
+        # Check ground ray collisions
+        if self.ground_handler.getNumEntries() > 0:
+            self.ground_handler.sortEntries() # Closest hit first
+            ground_contact = self.ground_handler.getEntry(0)
+            hit_pos = ground_contact.getSurfacePoint(self.base.render)
+            # Distance from player's origin (feet) to the ground contact point
+            # Ray origin is at self.model_height_offset from player NodePath's origin
+            # So, player's feet are at current_pos.z - self.model_height_offset
+            # Effective ray length to consider is short, e.g., 0.2 units down from feet
+            # Player's Z position is its center. Feet are at Z - model_height_offset.
+            # Ray starts at Z - model_height_offset + 0.05 and goes down.
+            # If hit_pos.z is very close to (current_pos.z - self.model_height_offset), we are on ground.
+
+            # Distance from player's feet (origin of ray) to the hit point
+            # The ray origin is self.ground_ray.getOrigin(), relative to self (Player NP)
+            # So, world origin of ray is self.getPos() + self.ground_ray.getOrigin()
+            # For simplicity, check if the hit is within a small tolerance below the player's model bottom
+
+            # Distance from player's origin to ground. Player origin is its center.
+            # Player feet are at current_pos.z - self.model_height_offset.
+            # If hit_pos.z is close to this, we are on ground.
+            # A small tolerance, e.g., if player's feet are within 0.1 of the hit surface.
+            if hit_pos.getZ() > current_pos.getZ() - self.model_height_offset - 0.1: # If hit is close below feet
+                self.on_ground = True
+                # Snap player to ground if they are slightly above or sunk in
+                self.setZ(hit_pos.getZ() + self.model_height_offset)
+                self.vertical_velocity = 0
+                self.is_jumping = False
+
+
+        # --- Apply Gravity ---
+        if not self.on_ground:
+            self.vertical_velocity += self.gravity * dt
+
+        # Update vertical position
+        delta_z = self.vertical_velocity * dt
+        self.setZ(self.getZ() + delta_z)
+
+        # --- Jumping ---
+        if self.key_map["jump"] and self.on_ground and not self.is_jumping:
+            self.vertical_velocity = self.jump_force
+            self.is_jumping = True
+            self.on_ground = False # Player leaves ground
+
+        # --- Horizontal Movement ---
+        # Movement is relative to the player's current heading (which is controlled by mouse in main.py)
+        move_direction = Vec3(0, 0, 0)
+        if self.key_map["forward"]:
+            move_direction.setY(move_direction.getY() + self.speed * dt)
+        if self.key_map["backward"]:
+            move_direction.setY(move_direction.getY() - self.speed * dt)
+        if self.key_map["left"]:
+            move_direction.setX(move_direction.getX() - self.speed * dt)
+        if self.key_map["right"]:
+            move_direction.setX(move_direction.getX() + self.speed * dt)
+
+        # Transform movement vector from player's local space to world space
+        # Player's rotation (H) is set by mouse in main.py
+        # We want to move along the player's local X and Y axes.
+        # self.getQuat().getForward() gives world-space forward vector
+        # self.getQuat().getRight() gives world-space right vector
+
+        # Simpler: move relative to self, then Panda3D handles world transform
+        # self.setPos(self, move_direction) works if self (Player NP) is rotated.
+        # The Player NodePath itself (self) is rotated by main.py's camera update.
+
+        # We need to apply the movement considering the player's rotation (H value)
+        # The player's H (heading) is set in main.py's update_camera_and_mouse_look
+        # So, self.getH() is the current heading.
+
+        # Calculate movement in world space based on player's heading
+        current_h_rad = self.getH() * (3.14159 / 180.0)
+        cos_h = math.cos(current_h_rad)
+        sin_h = math.sin(current_h_rad)
+
+        world_move_x = move_direction.getX() * cos_h - move_direction.getY() * sin_h
+        world_move_y = move_direction.getX() * sin_h + move_direction.getY() * cos_h
+
+        # Update position based on world movement vector
+        new_x = current_pos.getX() + world_move_x
+        new_y = current_pos.getY() + world_move_y
+        self.setX(new_x)
+        self.setY(new_y)
+
+        # After movement, collision pusher will handle block collisions.
+        # The ground ray collision will re-adjust Z if player falls onto a block.
+
+        return task.cont
+
+    def cleanup(self):
+        self.base.taskMgr.remove("update_player_task")
+        self.base.ignore("w")
+        self.base.ignore("w-up")
+        self.base.ignore("s")
+        self.base.ignore("s-up")
+        self.base.ignore("a")
+        self.base.ignore("a-up")
+        self.base.ignore("d")
+        self.base.ignore("d-up")
+        self.base.ignore("space")
+        self.base.ignore("space-up")
+
+        if self.ground_col_np:
+            self.base.cTrav.removeCollider(self.ground_col_np)
+            self.ground_col_np.removeNode()
+        if self.player_col_np:
+            self.base.cTrav.removeCollider(self.player_col_np) # Pusher handles its own removal from traverser if needed
+            self.player_col_np.removeNode()
+
+        self.model.removeNode()
+        self.removeNode()
+import math # Ensure math is imported if not already at top


### PR DESCRIPTION
Implemented a basic 2.5D/3D Minecraft-like game prototype with Panda3D.

Features:
- Player Class: Handles WASD movement (relative to camera), spacebar jump, and gravity. Player is represented by a sphere.
- First-Person Camera: Mouse-look controls player heading and camera pitch.
- Block System:
    - `Block` class for world elements.
    - Supports "grass" and "stone" block types.
    - Loads textures from a `textures/` directory (`grass_side.png`, `stone.png`) with fallback to solid colors.
- Block Interaction:
    - Left-click to break blocks.
    - Right-click to place blocks.
    - Mouse picking determines target block/location.
    - Player cannot place blocks inside themselves.
- World Generation: Simple flat world (10x10) with a layer of grass on top of stone.
- Collision System:
    - Player uses a ray for ground detection.
    - Player body (sphere) uses a `CollisionHandlerPusher` to interact with blocks.
    - Blocks have collision solids for interaction.
- Input: Keys '1' and '2' select stone and grass block types for placement.

The project structure includes `main.py`, `player.py`, and `block.py`. User needs to provide `textures/grass_side.png` and `textures/stone.png` for textures to load.